### PR TITLE
[GQ] #88: MainActor - ObservableObject를 MainActor와 함께 사용할 때 스레드 안전성은 어떻게 확보할 수 있을까

### DIFF
--- a/Docs/Air/MainActor/MainActor - ObservableObject를 MainActor와 함께 사용할 때 스레드 안전성은 어떻게 확보할 수 있을까.md
+++ b/Docs/Air/MainActor/MainActor - ObservableObject를 MainActor와 함께 사용할 때 스레드 안전성은 어떻게 확보할 수 있을까.md
@@ -1,0 +1,90 @@
+>[!question]
+>GQ. ObservableObject를 MainActor와 함께 사용할 때 스레드 안전성은 어떻게 확보할 수 있을까
+
+## Description
+- SwiftUI의 뷰는 상태 변화에 따라 자동으로 업데이트된다.
+- 이런 반응형 동작을 가능하게 하는 핵심요소는 `ObservableObject` (및 `@Observable`)이다.
+- SwiftUI에서 모든 UI 관련 작업은 메인 스레드에서만 수행되어야 한다.
+- 백그라운드 스레드에서 UI 요소나 이를 구동하는 `ObservableObject`의 `@Published` 속성을 직접 업데이트하려고 시도하면 "보라색 런타임 에러"가 발생한다.
+- `MainActor`는 특정 코드가 메인 스레드에서만 실행되도록 컴파일 시점에 보장하는 전역 액터이다.
+
+## 주요 기능
++ SwiftUI 및 UIKit는 Thread Safety 하지 않으므로, 모든 UI 업데이트는 반드시 메인 스레드에서 이루어져야 한다.
++ 따라서 `ObservableObject`에 `MainActor`를 사용하여 메인 스레드에서만 실행되도록 보장한다.
++ 클래스, 함수, 속성에 적용할 수 있고, 전체 클래스에 적용하면 모든 멤버가 메인 액터에 격리된다.
+
+## 코드 예시
+#### 잘못된 예 (보라색 에러 발생)
+```Swift
+class MyViewModel: ObservableObject {
+    @Published var message: String = "초기 메시지"
+
+    func fetchMessageFromBackground() {
+        DispatchQueue.global().async {
+            let fetchedMessage = "백그라운드에서 가져온 메시지"
+            self.message = fetchedMessage // "Publishing changes from background thread" 보라색 런타임 문제 발생
+        }
+    }
+}
+
+struct MyView: View {
+    @StateObject var viewModel = MyViewModel()
+
+    var body: some View {
+        VStack {
+            Text(viewModel.message)
+            Button("메시지 가져오기 (잘못된 방식)") {
+                viewModel.fetchMessageFromBackground()
+            }
+        }
+    }
+}
+```
+#### MainActor 사용한 올바른 예
+```Swift
+@MainActor // ViewModel 전체를 MainActor에 격리
+class MyViewModel: ObservableObject {
+    @Published var message: String = "초기 메시지"
+    @Published var isLoading: Bool = false
+
+    func fetchMessageFromBackgroundSafe() async {
+        isLoading = true
+        let fetchedMessage = await Task.detached {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            return "백그라운드에서 안전하게 가져온 메시지"
+        }.value
+
+        // ViewModel이 @MainActor에 격리되어 있으므로,
+        // 이 속성 업데이트는 자동으로 메인 스레드에서 이루어짐
+        self.message = fetchedMessage?? "데이터 로드 실패"
+        isLoading = false
+    }
+}
+
+struct MyView: View {
+    @StateObject var viewModel = MyViewModel()
+
+    var body: some View {
+        VStack {
+            if viewModel.isLoading {
+                ProgressView("메시지 로드 중...")
+            } else {
+                Text(viewModel.message)
+            }
+            Button("메시지 가져오기 (안전한 방식)") {
+                Task {
+                    await viewModel.fetchMessageFromBackgroundSafe()
+                }
+            }
+        }
+    }
+}
+```
+
+## Keywords
++ [[MainActor]]
++ [[ObservableObject]]
++ [[병렬 처리(Swift-Concurrency)]]
+
+## 작성자
+- #Air 


### PR DESCRIPTION
### 🌱 Challenge 정보
- **주차:** [Week 5]
- **주제:** "ObservableObject를 MainActor와 함께 사용할 때 스레드 안전성은 어떻게 확보할 수 있을까"
- **관련 이슈:** #88 

### 📌 Check List
- [x] 키워드 연결 확인
<img width="340" alt="Screenshot 2025-06-29 at 1 45 26 AM" src="https://github.com/user-attachments/assets/f85df2d7-54dc-4970-bd56-5c1d5a0466f5" />

### ✨ 나의 Finding & Synthesis
- 알게 된 점 1. Publishing changes from background thread is not allowed 에러(보라색 런타임 에러)의 원인과 해결 방법

### ✅ 팀원 확인
- [ ] 팀원 1: @nan-park 박난 니카
- [ ] 팀원 2: @yijuuuun 김이준 세라
- [x] 팀원 3: @yangsijun 양시준 에어
- [ ] 팀원 4: @freeskyES 천은송 원띵
- [ ] 팀원 5: @whalswjd 조민정 젠
- [ ] 팀원 6: @JwithHama 이주함 하마
- [ ] 팀원 7: @01sys10 소연수 노터

### ⚡ 리뷰어 확인
- [ ] 학습 내용 검토 완료
- [ ] 추가 학습 필요 시 코멘트

### ⁉️ 새롭게 생긴 Curiosity
1. `@Observable`에서는 스레드 안전성을 어떻게 확보할 수 있을까
