### PR TITLE
[gq] #88: Closure - 클로저 내부에서 async 함수를 호출할 수 있는 조건은 무엇인가

### DIFF
--- a/Docs/Air/Closure/Closure - 클로저 내부에서 async 함수를 호출할 수 있는 조건은 무엇인가.md
+++ b/Docs/Air/Closure/Closure - 클로저 내부에서 async 함수를 호출할 수 있는 조건은 무엇인가.md
@@ -1,0 +1,62 @@
+>[!question]
+>GQ. 클로저 내부에서 async 함수를 호출할 수 있는 조건은 무엇인가
+
+## Description
+- Swift에서 클로저는 코드를 그룹화하고 전달하며, 주변 컨텍스트의 변수와 상수를 캡처하고 저장할 수 있는 강력하고 유연한 기능이다.
+- 과거에는 `DispatchQueue`를 활용한 GCD나 클로저 기반의 완료 핸들러(completion handler)가 비동기 작업을 처리하는 주된 방식이었다.
+- `async/await`와 기존의 클로저 기반의 코드 및 API와의 통합은 중요한 과제이다.
+
+## 주요 기능
+#### 클로저 내 `async` 함수 호출 조건
+- `async` 함수는 `await` 키워드를 사용하여 비동기 컨텍스트 내에서만 직접적으로 호출될 수 있다.
+- `async`가 아닌 클로저에서 `async`함수를 호출 하려면 해당 호출을 `Task` 블록으로 래핑하여 새로운 비동기 컨텍스트를 생성해야 한다.
+- `Task {...}`는 새로운 동시성 작업을 생성하고 즉시 실행을 시작하는 역할을 하며, 이 또한 클로저의 한 형태이다.
+
+## 코드 예시
+1. 일반 클로저 내 `Task` 블록을 사용하여 `async` 함수를 호출
+```Swift
+func performLegacyClosure(completion: @escaping (String) -> Void) {
+	// 이 클로저는 async 컨텍스트가 아님
+	DispatchQueue.global().async {
+		// Task 블록 내에서 async 함수 호출
+		Task {
+			do {
+				let data = try await fetchDataAsync()
+				completion("Data fetched: \(data.count)bytes")
+			} catch {
+				completion("Error: \(error.localizedDescription)")
+			}
+		}
+	}
+}
+
+func fetchDataAsync() async throws -> Data {
+	try await Task.sleep(for:.seconds(1))
+	return Data("Hello, Swift Concurrency!".utf8)
+}
+```
+2. `withCheckedContinuation`을 사용하여 클로저 기반 API를 `async/await`로 래핑
+```Swift
+// async/await로 래핑: 기존 클로저를 async 함수처럼 사용할 수 있게 됨
+func fetchDataAsyncWrapped() async -> Data {
+	return await withCheckedContinuation { coutinuation in
+		fetchData { data in
+			coutinuation.resume(returning: data ?? Data()) // 클로저 결과가 나오면 continuation 재개
+		}
+	}
+}
+
+// 기존 클로저 기반 함수
+func fetchData(completion: @escaping (Data?) -> Void) {
+	DispatchQueue.global().asyncAfter(deadline: .now() + 1) {
+		completion(Data("Some data".uft8))
+	}
+}
+```
+## Keywords
++ [[클로저 (Closure)]]
++ [[Task]]
++ [[병렬 처리(Swift-Concurrency)]]
+
+## 작성자
+- #Air 


### PR DESCRIPTION
### 🌱 Challenge 정보
- **주차:** [Week 5]
- **주제:** "클로저 내부에서 async 함수를 호출할 수 있는 조건은 무엇인가"
- **관련 이슈:** #88 

### 📌 Check List
- [x] 키워드 연결 확인
<img width="460" alt="Screenshot 2025-06-29 at 2 47 58 AM" src="https://github.com/user-attachments/assets/11702373-0fea-4eca-9e02-1c09d8e22f6c" />

### ✨ 나의 Finding & Synthesis
- 알게 된 점 1. `async/await`와 기존의 클로저 기반의 코드 및 API와의 통합은 중요한 과제이다.
- 알게 된 점 2. `async`가 아닌 클로저에서 `async`함수를 호출 하려면 해당 호출을 `Task` 블록으로 래핑하여 새로운 비동기 컨텍스트를 생성해야 한다.

### ✅ 팀원 확인
- [ ] 팀원 1: @nan-park 박난 니카
- [ ] 팀원 2: @yijuuuun 김이준 세라
- [x] 팀원 3: @yangsijun 양시준 에어
- [ ] 팀원 4: @freeskyES 천은송 원띵
- [ ] 팀원 5: @whalswjd 조민정 젠
- [ ] 팀원 6: @JwithHama 이주함 하마
- [ ] 팀원 7: @01sys10 소연수 노터

### ⚡ 리뷰어 확인
- [ ] 학습 내용 검토 완료
- [ ] 추가 학습 필요 시 코멘트

### ⁉️ 새롭게 생긴 Curiosity
1. 클로저 기반 비동기에서 async/await 비동기로 전환된 이유는 무엇일까